### PR TITLE
fix(i18n): Web版向けにセットアップ画面のテキストを修正する

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -67,7 +67,7 @@
   "login-page:error-invalid-credentials": "Invalid credentials",
   "login-page:error-invalid-2fa": "Invalid 2FA code",
   "setup-page:welcome-title": "Welcome to VRChat Worlds Manager Web",
-  "setup-page:thank-you": "Thank you for installing!",
+  "setup-page:thank-you": "Thank you for using VRChat Worlds Manager Web!",
   "setup-page:first-time": "Since this is your first time here, let's take a moment to set up VRChat Worlds Manager Web just the way you like it.",
   "setup-page:not-first-time:foretext": "Not your first time? Please contact us through ",
   "setup-page:github-issues": "GitHub Issues",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -67,7 +67,7 @@
   "login-page:error-invalid-credentials": "認証情報が無効です",
   "login-page:error-invalid-2fa": "無効な2FAコードです",
   "setup-page:welcome-title": "VRChat Worlds Manager Web へようこそ",
-  "setup-page:thank-you": "インストールしていただきありがとうございます！",
+  "setup-page:thank-you": "ご利用ありがとうございます！",
   "setup-page:first-time": "初回起動のため、VRChat Worlds Manager Web の初期設定を行います",
   "setup-page:not-first-time:foretext": "もし初回起動ではないのにこの画面が出る場合、",
   "setup-page:github-issues": "GitHub Issues",


### PR DESCRIPTION
## Summary

- issue #7 で指摘されていたデスクトップアプリ前提のユーザー向けテキストを Web 版向けに修正

## Changes

- `locales/ja-JP.json` / `locales/en-US.json`: `setup-page:thank-you` を「インストール」を前提としない文言に変更（ja: 「ご利用ありがとうございます！」、en: "Thank you for using VRChat Worlds Manager Web!"）

## 補足

issue #7 で挙げられていた他の項目（`settings-page:logs-description` / `settings-page:update-channel-description` キー、`error-content.tsx` のログ・フォルダを開くボタン、設定画面のアップデートチャンネル UI）は、Tauri → Web 移行の過程ですでに削除されており、このブランチ（`feature/web`）には該当コードが存在しませんでした。差分を確認した結果、修正が必要だったのは `setup-page:thank-you` のみでした。

## Test plan

- [x] `bun run typecheck` が通ることを確認
- [x] `bun run test:unit` が通ることを確認（`tests/unit/locales.test.ts` を含む）
- [x] `bunx prettier --check` で変更ファイルのフォーマットを確認
- [x] `bun run check` の ESLint エラーは本 PR の変更とは無関係な既存の問題であることを確認（`git stash` してベースブランチでも同じエラーが出ることを確認済み）

Closes #7